### PR TITLE
fix: Move error handler middleware before routes to properly catch validation errors

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -20,13 +20,7 @@ export function createApp(): Application {
     await next();
   });
 
-  // Routes
-  app.use(healthRouter.routes());
-  app.use(healthRouter.allowedMethods());
-  app.use(executeRouter.routes());
-  app.use(executeRouter.allowedMethods());
-
-  // Error handler
+  // Error handler (must be before routes to catch route errors)
   app.use(async (ctx: Context, next) => {
     try {
       await next();
@@ -61,6 +55,12 @@ export function createApp(): Application {
       } satisfies ApiResponse;
     }
   });
+
+  // Routes
+  app.use(healthRouter.routes());
+  app.use(healthRouter.allowedMethods());
+  app.use(executeRouter.routes());
+  app.use(executeRouter.allowedMethods());
 
   // 404 handler (must be last)
   app.use((ctx) => {


### PR DESCRIPTION
The error handler was previously registered after the routers, which meant
that RestExecError exceptions (like ValidationError from validateExecuteRequest)
were not being caught. This caused Oak's default 500 HTML responses instead of
the structured JSON error responses with proper status codes (400, 404, 408, etc.)
as specified in specs/API.md.

Changes:
- Moved error handler middleware (lines 24-57) before route registration
- Added clarifying comment about middleware order requirement
- Ensures all route errors are properly caught and return structured JSON
- Prevents stack trace leakage to clients

This fixes the bug where validation errors returned Oak's default 500 HTML
instead of 400 JSON responses with proper error structure.

- close #18
