### PR TITLE
docs: Fix documentation specs for environment variables and import map deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ WORKDIR /app
 
 # Copy application files
 COPY deno.json ./
-COPY import_map.json ./workspace/
 COPY src ./src
 
 # Cache dependencies
@@ -14,6 +13,9 @@ RUN deno cache src/index.ts
 
 # Create workspace and tools directories
 RUN mkdir -p /workspace /tools
+
+# Copy import map to workspace (used by child Deno processes)
+COPY import_map.json /workspace/
 
 # Switch to deno user
 RUN chown -R deno:deno /workspace /tools

--- a/specs/Configuration.md
+++ b/specs/Configuration.md
@@ -4,15 +4,15 @@
 
 | 変数名 | デフォルト値 | 説明 |
 |-------|-----------|------|
-| `PORT` | 8080 | HTTPサーバーのリスニングポート |
-| `LOG_LEVEL` | INFO | ログレベル (DEBUG, INFO, WARN, ERROR) |
+| `PORT` | 3000 | HTTPサーバーのリスニングポート |
+| `LOG_LEVEL` | info | ログレベル (DEBUG, INFO, WARN, ERROR) |
 
 ## 実行設定
 
 | 変数名 | デフォルト値 | 説明 |
 |-------|-----------|------|
-| `DEFAULT_TIMEOUT_MS` | 5000 | デフォルトタイムアウト（ミリ秒） |
-| `MAX_TIMEOUT_MS` | 300000 | 最大タイムアウト（ミリ秒） |
+| `DEFAULT_TIMEOUT` | 5000 | デフォルトタイムアウト（ミリ秒） |
+| `MAX_TIMEOUT` | 300000 | 最大タイムアウト（ミリ秒） |
 | `WORKSPACE_DIR` | /workspace | コード実行ディレクトリ |
 | `TOOLS_DIR` | /tools | 共有ツールディレクトリ |
 

--- a/specs/Deployment.md
+++ b/specs/Deployment.md
@@ -29,3 +29,20 @@ volumes:
     mountPath: /tools
     readOnly: true
 ```
+
+### Import Map の配置
+
+Deno の子プロセスは `/workspace/import_map.json` を使用してモジュール解決を行います。
+
+**デフォルト構成:**
+- Docker イメージには基本的な import_map.json が `/workspace/` に含まれています
+- この import_map.json はビルド時にコピーされます
+
+**カスタム構成:**
+- カスタムの import_map.json を使用する場合は、`/workspace` をマウントする際にホスト側の import_map.json を含めてください
+- 例: `./example/workspace:/workspace` のようにマウントすると、ホスト側の import_map.json が使用されます
+
+**注意事項:**
+- ホストマウントなしでデプロイする場合、イメージに含まれるデフォルトの import_map.json が使用されます
+- カスタムの import_map.json が必要な場合は、独自の Dockerfile を作成して適切なファイルをコピーしてください
+- `DENO_IMPORT_MAP` 環境変数でパスを変更できますが、対応するファイルが存在することを確認してください


### PR DESCRIPTION
Fixes #21, #24

**Environment Variable Specification Alignment:**
- Corrected specs/Configuration.md to match implementation
- Changed PORT default from 8080 to 3000
- Changed DEFAULT_TIMEOUT_MS to DEFAULT_TIMEOUT
- Changed MAX_TIMEOUT_MS to MAX_TIMEOUT
- Changed LOG_LEVEL default from INFO to info
- These changes align with actual implementation in src/config.ts and compose.yaml

**Import Map Deployment Fix:**
- Fixed Dockerfile to copy import_map.json to /workspace/ after directory creation
- Previously copied to /app/workspace/ which was incorrect path
- Added documentation in specs/Deployment.md explaining import map placement
- Ensures import_map.json is available at /workspace/import_map.json even without host mounts