### PR TITLE
refactor: migrate all Deno std library imports to JSR

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -6,9 +6,9 @@
   "imports": {
     "@oak/oak": "https://deno.land/x/oak@v17.1.6/mod.ts",
     "@std/encoding": "jsr:@std/encoding@^1.0.10",
-    "@std/path": "https://deno.land/std@0.224.0/path/mod.ts",
-    "@std/assert": "https://deno.land/std@0.224.0/assert/mod.ts",
-    "@std/testing": "https://deno.land/std@0.224.0/testing/mod.ts",
+    "@std/path": "jsr:@std/path@^1.0.10",
+    "@std/assert": "jsr:@std/assert@^1.0.10",
+    "@std/testing": "jsr:@std/testing@^1.0.10",
     "@/": "./tools/",
     "utils/": "./tools/utils/",
     "types": "./tools/types.ts"

--- a/deno.lock
+++ b/deno.lock
@@ -3,12 +3,14 @@
   "specifiers": {
     "jsr:@oak/commons@1": "1.0.1",
     "jsr:@std/assert@1": "1.0.15",
+    "jsr:@std/assert@^1.0.10": "1.0.15",
     "jsr:@std/bytes@1": "1.0.6",
     "jsr:@std/crypto@1": "1.0.5",
     "jsr:@std/encoding@1": "1.0.10",
     "jsr:@std/encoding@^1.0.10": "1.0.10",
     "jsr:@std/http@1": "1.0.21",
     "jsr:@std/internal@^1.0.10": "1.0.12",
+    "jsr:@std/internal@^1.0.12": "1.0.12",
     "jsr:@std/media-types@1": "1.1.0",
     "jsr:@std/path@1": "1.1.2",
     "jsr:@std/path@1.0.8": "1.0.8",
@@ -20,7 +22,7 @@
     "@oak/commons@1.0.1": {
       "integrity": "889ff210f0b4292591721be07244ecb1b5c118742f5273c70cf30d7cd4184d0c",
       "dependencies": [
-        "jsr:@std/assert",
+        "jsr:@std/assert@1",
         "jsr:@std/bytes",
         "jsr:@std/crypto",
         "jsr:@std/encoding@1",
@@ -29,7 +31,10 @@
       ]
     },
     "@std/assert@1.0.15": {
-      "integrity": "d64018e951dbdfab9777335ecdb000c0b4e3df036984083be219ce5941e4703b"
+      "integrity": "d64018e951dbdfab9777335ecdb000c0b4e3df036984083be219ce5941e4703b",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
+      ]
     },
     "@std/bytes@1.0.6": {
       "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
@@ -58,7 +63,7 @@
     "@std/path@1.1.2": {
       "integrity": "c0b13b97dfe06546d5e16bf3966b1cadf92e1cc83e56ba5476ad8b498d9e3038",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.10"
       ]
     }
   },
@@ -219,7 +224,10 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@std/encoding@^1.0.10"
+      "jsr:@std/assert@^1.0.10",
+      "jsr:@std/encoding@^1.0.10",
+      "jsr:@std/path@^1.0.10",
+      "jsr:@std/testing@^1.0.10"
     ]
   }
 }

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -1,4 +1,4 @@
-import { join } from 'jsr:@std/path@^1.0.10';
+import { join } from '@std/path';
 import { logger } from './utils/logger.ts';
 import { ExecutionError, FileNotFoundError, TimeoutError } from './utils/errors.ts';
 import { config } from './config.ts';

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -1,4 +1,4 @@
-import { join } from 'jsr:@std/path@^1.0.10';
+import { join } from '@std/path';
 import { logger } from './utils/logger.ts';
 import { ExecutionError, FileNotFoundError, TimeoutError } from './utils/errors.ts';
 import { config } from './config.ts';

--- a/src/routes/workspace.ts
+++ b/src/routes/workspace.ts
@@ -1,5 +1,5 @@
 import { Router } from '@oak/oak';
-import { join } from 'jsr:@std/path@^1.0.0';
+import { join } from '@std/path';
 import type { ApiResponse, WorkspaceSaveRequest, WorkspaceSaveResult } from '../types/index.ts';
 import { validateWorkspaceSaveRequest } from '../middleware/validation.ts';
 import { config } from '../config.ts';

--- a/tests/integration/workspace.test.ts
+++ b/tests/integration/workspace.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals, assertExists } from '@std/assert';
 import { createApp } from '../../src/app.ts';
 import type { ApiResponse, ErrorResponse, WorkspaceSaveResult } from '../../src/types/index.ts';
-import { join } from 'jsr:@std/path@1.0.8';
+import { join } from '@std/path';
 import { config } from '../../src/config.ts';
 
 /**


### PR DESCRIPTION
- Update @std/path from deno.land/std@0.224.0 to jsr:@std/path@^1.0.10
  - Update @std/assert from deno.land/std@0.224.0 to jsr:@std/assert@^1.0.10
  - Update @std/testing from deno.land/std@0.224.0 to jsr:@std/testing@^1.0.10
  - Replace direct JSR URLs with import map aliases in source files
  - Consolidate multiple versions into unified JSR-based imports

  This migration follows Deno's official recommendation:
  https://deno.com/blog/std-on-jsr

  Benefits:
  - Future support for new features (JSR only)
  - Better version management with semver
  - Multi-runtime compatibility (Deno, Node.js, browsers)
  - Latest stable versions (v1.0.15)