### PR TITLE
fix: Implement --no-remote flag in Deno executor

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -9,7 +9,7 @@ import { runProcess } from './utils/processRunner.ts';
  * Build Deno command arguments with permissions
  */
 function buildDenoArgs(filePath: string): string[] {
-  const args = ['run', '--no-prompt', '--cached-only'];
+  const args = ['run', '--no-prompt', '--cached-only', '--no-remote'];
 
   // Add import map
   if (config.deno.importMap) {


### PR DESCRIPTION
Add --no-remote flag to Deno command arguments to prevent
network access during execution, as specified in specs/Security.md.
This enhances security by ensuring only cached dependencies are used.

Resolves #71