### PR TITLE
refactor: 共通定数をconfig.tsに集約

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,15 @@ function parseBooleanEnv(envVar: string | undefined, defaultValue: boolean): boo
   return envVar.toLowerCase() === 'true';
 }
 
+/**
+ * Shared constants used across multiple modules
+ */
+export const constants = {
+  MAX_BUFFER: 10 * 1024 * 1024, // 10MB
+  SIGKILL_GRACE_PERIOD_MS: 1000, // 1 second
+  MAX_CODE_SIZE: 10 * 1024 * 1024, // 10MB
+} as const;
+
 export const config = {
   port: parseInt(Deno.env.get('PORT') || '3000', 10),
   workspaceDir: Deno.env.get('WORKSPACE_DIR') || '/workspace',

--- a/src/middleware/validation.ts
+++ b/src/middleware/validation.ts
@@ -1,5 +1,5 @@
 import { Context } from '@oak/oak';
-import { config } from '../config.ts';
+import { config, constants } from '../config.ts';
 import { ValidationError } from '../utils/errors.ts';
 import type { ExecuteRequest, LintRequest, WorkspaceSaveRequest } from '../types/index.ts';
 
@@ -248,13 +248,12 @@ export async function validateWorkspaceSaveRequest(ctx: Context, next: () => Pro
   }
 
   // Validate code size (10MB limit)
-  const MAX_CODE_SIZE = 10 * 1024 * 1024; // 10MB
   const encoder = new TextEncoder();
   const codeBytes = encoder.encode(code);
-  if (codeBytes.length > MAX_CODE_SIZE) {
+  if (codeBytes.length > constants.MAX_CODE_SIZE) {
     throw new ValidationError(
       'Code size exceeds maximum allowed size',
-      { field: 'code', maxSize: MAX_CODE_SIZE, actualSize: codeBytes.length },
+      { field: 'code', maxSize: constants.MAX_CODE_SIZE, actualSize: codeBytes.length },
     );
   }
 

--- a/src/utils/processRunner.ts
+++ b/src/utils/processRunner.ts
@@ -1,16 +1,9 @@
 import { logger } from './logger.ts';
 import { ExecutionError, TimeoutError } from './errors.ts';
 import { processManager } from './processManager.ts';
+import { constants } from '../config.ts';
 
-/**
- * Maximum buffer size for stdout/stderr (10MB)
- */
-export const MAX_BUFFER = 10 * 1024 * 1024;
-
-/**
- * Grace period before sending SIGKILL after SIGTERM (1 second)
- */
-export const SIGKILL_GRACE_PERIOD_MS = 1000;
+const { MAX_BUFFER, SIGKILL_GRACE_PERIOD_MS } = constants;
 
 /**
  * Process execution result containing raw output and metadata


### PR DESCRIPTION
重複定義されていた定数を整理し、保守性を向上:
- MAX_BUFFER (processRunner.ts)
- SIGKILL_GRACE_PERIOD_MS (processRunner.ts)
- MAX_CODE_SIZE (validation.ts)

これらの定数をsrc/config.tsの新しいconstantsオブジェクトに移動し、
各モジュールからインポートする形に変更。

close #66
