### PR TITLE
fix: JSDocコメントの重複を削除

### DIFF
--- a/src/middleware/validation.ts
+++ b/src/middleware/validation.ts
@@ -9,8 +9,6 @@ import { FORBIDDEN_ENV_KEYS } from '../constants/security.ts';
  * @param codeId - The code identifier to validate
  * @param options - Optional validation options
  * @throws {ValidationError} If validation fails
- * @param options - Optional validation options
- * @throws {ValidationError} If validation fails
  */
 function validateCodeId(codeId: unknown, options?: { maxLength?: number }): void {
   // Validate codeId presence
@@ -50,7 +48,6 @@ function validateCodeId(codeId: unknown, options?: { maxLength?: number }): void
 
 /**
  * Validates timeout field
- * @param timeout - The timeout value to validate (optional)
  * @param timeout - The timeout value to validate (optional)
  * @throws {ValidationError} If validation fails
  */


### PR DESCRIPTION
validation.ts内の2箇所でJSDocコメントが重複していた問題を修正:
- validateCodeId関数 (7-13行目): @param と @throws の重複を削除
- validateTimeout関数 (52-55行目): @param の重複を削除

Ref:
- close #67