### PR TITLE
refactor: 型アサーションを instanceof チェックに置き換え (#70)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -35,23 +35,23 @@ export function createApp(): Application {
       await next();
     } catch (err) {
       const executionTime = Date.now() - ctx.state.startTime;
+      const error = err instanceof Error ? err : new Error(String(err));
 
-      if (err instanceof RestExecError) {
-        logger.warn(`Request failed with ${err.type}: ${err.message}`);
-        ctx.response.status = err.statusCode;
+      if (error instanceof RestExecError) {
+        logger.warn(`Request failed with ${error.type}: ${error.message}`);
+        ctx.response.status = error.statusCode;
         ctx.response.body = {
           success: false,
           error: {
-            type: err.type,
-            message: err.message,
-            details: err.details,
+            type: error.type,
+            message: error.message,
+            details: error.details,
           },
           executionTime,
         } satisfies ApiResponse;
         return;
       }
 
-      const error = err instanceof Error ? err : new Error(String(err));
       logger.error('Unhandled error', error);
       ctx.response.status = 500;
       ctx.response.body = {

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -104,10 +104,10 @@ function parseLintOutput(
       };
     }
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    logger.error(`Failed to parse lint JSON output: ${errorMessage}`);
+    const wrappedError = error instanceof Error ? error : new Error(String(error));
+    logger.error(`Failed to parse lint JSON output: ${wrappedError.message}`, wrappedError);
     throw new ExecutionError('Failed to parse lint output as JSON', {
-      error: errorMessage,
+      error: wrappedError.message,
       stdout: stdout.trim(),
       stderr: stderr.trim(),
     });

--- a/src/utils/processRunner.ts
+++ b/src/utils/processRunner.ts
@@ -133,7 +133,8 @@ export async function runProcess(
         }
       })().catch((error) => {
         // Stream reading errors should not crash the process
-        logger.warn(`Error reading stdout for ${codeId}: ${error.message}`);
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logger.warn(`Error reading stdout for ${codeId}: ${errorMessage}`);
       });
 
       // Read stderr with buffer limit enforcement
@@ -164,7 +165,8 @@ export async function runProcess(
         }
       })().catch((error) => {
         // Stream reading errors should not crash the process
-        logger.warn(`Error reading stderr for ${codeId}: ${error.message}`);
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        logger.warn(`Error reading stderr for ${codeId}: ${errorMessage}`);
       });
 
       // Set up timeout with SIGTERM → SIGKILL escalation
@@ -237,11 +239,11 @@ export async function runProcess(
           }
 
           isSettled = true;
-          const processError = error instanceof Error ? error : new Error(String(error));
-          logger.error(`Process error for ${codeId}:`, processError);
+          const normalizedError = error instanceof Error ? error : new Error(String(error));
+          logger.error(`Process error for ${codeId}:`, normalizedError);
           reject(
-            new ExecutionError(`Failed to execute process: ${processError.message}`, {
-              error: processError.message,
+            new ExecutionError(`Failed to execute process: ${normalizedError.message}`, {
+              error: normalizedError.message,
             }),
           );
         }


### PR DESCRIPTION
catch ブロックで捕捉したエラーの型アサーション (`as Error`) を
instanceof チェックに置き換え、より安全なエラーハンドリングを実装。

修正箇所:
- src/app.ts: エラーハンドリングミドルウェア
- src/linter.ts: lint 出力のパース処理
- src/utils/processRunner.ts: プロセス実行のエラー処理

Ref:
- close #70