### PR TITLE
docs(mcp-gateway): Update API.md spec to match actual implementation

### DIFF
--- a/services/mcp-gateway/specs/API.md
+++ b/services/mcp-gateway/specs/API.md
@@ -354,9 +354,9 @@ curl -X POST http://localhost:3001/mcp/call \
 | `tools[].name`        | string  | Tool 名                            |
 | `tools[].description` | string  | Tool の説明                        |
 | `tools[].server`      | string  | Tool を提供する MCP Server 名      |
-| `tools[].inputSchema` | object  | Tool の入力スキーマ（JSON Schema） |
-| `tools[].outputSchema` | object | Tool の出力スキーマ（JSON Schema、MCP Server から返された値の形式） |
-| `tools[].timeout` | number | このツールに設定されたタイムアウト（ミリ秒）。デフォルト: 30000（30秒） |
+| `tools[].inputSchema` | object  | **必須**。Tool の入力スキーマ（JSON Schema）。Tool に渡す必須パラメータと型を定義します。JSON Schema は [MCP 仕様 Version 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25) に準拠しています。 |
+| `tools[].outputSchema` | object | **必須**。Tool の出力スキーマ（JSON Schema）。MCP Server から返される値の形式を定義します。JSON Schema は [MCP 仕様 Version 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25) に準拠しています。 |
+| `tools[].timeout` | number | **必須**。このツールに設定されたタイムアウト（ミリ秒）。`config.yaml` の `servers[].timeout` から取得。デフォルト: 30000（30秒）。詳細は [Configuration.md](Configuration.md) を参照。 |
 
 ### 使用例
 

--- a/services/mcp-gateway/specs/MCPProtocol.md
+++ b/services/mcp-gateway/specs/MCPProtocol.md
@@ -402,10 +402,12 @@ func stopMCPClient(
 
 ```go
 type ToolInfo struct {
-	Name        string                 `json:"name"`
-	Description string                 `json:"description"`
-	Server      string                 `json:"server"` // どの MCP Server が提供しているか
-	InputSchema map[string]any `json:"inputSchema"`
+	Timeout      int                    `json:"timeout"`             // Tool に設定されたタイムアウト（ミリ秒）
+	Name         string                 `json:"name"`                // Tool 名
+	Description  string                 `json:"description"`         // Tool の説明
+	Server       string                 `json:"server"`              // どの MCP Server が提供しているか
+	InputSchema  map[string]any         `json:"inputSchema"`         // Tool の入力スキーマ（JSON Schema）
+	OutputSchema map[string]any         `json:"outputSchema"`        // Tool の出力スキーマ（JSON Schema）- MCP Server が提供
 }
 
 // キャッシュ
@@ -415,10 +417,12 @@ var toolsCacheMutex sync.RWMutex
 // 例
 toolsCacheMutex.Lock()
 toolsCache["calculate-bmi"] = ToolInfo{
-	Name:        "calculate-bmi",
-	Description: "Calculate Body Mass Index",
-	Server:      "health-server",
-	InputSchema: map[string]any{ /* ... */ },
+	Timeout:      30000,
+	Name:         "calculate-bmi",
+	Description:  "Calculate Body Mass Index",
+	Server:       "health-server",
+	InputSchema:  map[string]any{ /* ... */ },
+	OutputSchema: map[string]any{ /* ... */ },
 }
 toolsCacheMutex.Unlock()
 ```
@@ -641,7 +645,7 @@ func mapJSONRPCErrorToHTTP(jsonrpcError JSONRPCError) HTTPError {
 
 1. タイムアウトを検知
 2. `TimeoutError` を throw
-3. HTTP レスポンスで `TIMEOUT_ERROR` (408) を返却
+3. HTTP レスポンスで `TIMEOUT_ERROR` (504) を返却
 4. MCP Server プロセスは維持（次のリクエストに備える）
 
 **注意事項**:

--- a/services/mcp-gateway/specs/Sequence.md
+++ b/services/mcp-gateway/specs/Sequence.md
@@ -54,7 +54,7 @@ sequenceDiagram
         deactivate MCP
         alt Timeout
             MCPMgr-->>HTTP: TimeoutError
-            HTTP-->>Client: 408 Request Timeout
+            HTTP-->>Client: 504 Gateway Timeout
         end
         alt JSON-RPC Error
             MCPMgr->>MCPMgr: Map error to HTTP
@@ -104,7 +104,7 @@ stateDiagram-v2
     WaitResponse --> ProcessJSONRPCError: JSON-RPC error
     WaitResponse --> ProcessSuccess: Tool result received
 
-    ProcessTimeout --> ReturnError408: Cancel request
+    ProcessTimeout --> ReturnError504: Cancel request
 
     ProcessJSONRPCError --> MapError: Map to HTTP error
     MapError --> ReturnError400: -32600, -32602
@@ -117,9 +117,9 @@ stateDiagram-v2
 
     ReturnError400 --> [*]: 400 Bad Request
     ReturnError404 --> [*]: 404 Not Found
-    ReturnError408 --> [*]: 408 Request Timeout
     ReturnError500 --> [*]: 500 Internal Error
     ReturnError503 --> [*]: 503 Service Unavailable
+    ReturnError504 --> [*]: 504 Gateway Timeout
     ReturnSuccess --> [*]: 200 OK
 
     note right of ValidateRequest
@@ -313,7 +313,7 @@ sequenceDiagram
     Note over MCPMgr: JSON-RPC Cancel Request<br/>is NOT sent (initial implementation)
 
     MCPMgr-->>HTTP: TimeoutError
-    HTTP-->>Client: 408 Request Timeout<br/>{error: {code: "TIMEOUT_ERROR", ...}}
+    HTTP-->>Client: 504 Gateway Timeout<br/>{error: {code: "TIMEOUT_ERROR", ...}}
 
     Note over MCP: Tool continues executing<br/>(until completion or crash)
     MCP->>Process: stdout: {"result": {...}}
@@ -429,7 +429,7 @@ sequenceDiagram
 
 **失敗時の動作**:
 
-- タイムアウト → `TIMEOUT_ERROR` (408)
+- タイムアウト → `TIMEOUT_ERROR` (504)
 - JSON-RPC エラー → エラーコードに応じて 400/404/500
 
 **注意**


### PR DESCRIPTION
- Add missing `outputSchema` field to GET /mcp/tools response
  - Documents the JSON Schema of Tool output from MCP Server
- Add missing `timeout` field to GET /mcp/tools response
  - Shows configured timeout in milliseconds for each Tool
- Fix TIMEOUT_ERROR HTTP status code: 408 → 504 (Gateway Timeout)
  - Aligns specification with actual implementation behavior
  - Updates error code table, status code reference table, and timeout processing section