### PR TITLE
feat: Introduce `StatusRestarting` to block API requests during server restarts and enhance restart process control.

### DIFF
--- a/services/mcp-gateway/internal/mcp/client_manager.go
+++ b/services/mcp-gateway/internal/mcp/client_manager.go
@@ -239,7 +239,7 @@ func (m *ClientManager) CallTool(ctx context.Context, server, toolName string, i
 	// Check status
 	status := m.processManager.GetStatus(server)
 	if status == StatusRestarting {
-		return nil, fmt.Errorf("server %s is currently restarting, please retry after 10 seconds", server)
+		return nil, fmt.Errorf("server %s is currently restarting, please retry shortly", server)
 	} else if status == StatusCrashed {
 		return nil, mcpErrors.ErrServerCrashed
 	} else if status != StatusAvailable {

--- a/services/mcp-gateway/internal/mcp/health_check_test.go
+++ b/services/mcp-gateway/internal/mcp/health_check_test.go
@@ -184,6 +184,9 @@ func TestRestartServer_MaxAttemptsExceeded(t *testing.T) {
 
 	cfg := config.ServerConfig{Name: "test-server"}
 
+	// Set initial status to Crashed (as would be set by health check)
+	pm.SetStatus("test-server", StatusCrashed)
+
 	// Simulate 3 previous attempts (max is 3)
 	pm.IncrementRestartAttempts("test-server")
 	pm.IncrementRestartAttempts("test-server")
@@ -195,21 +198,15 @@ func TestRestartServer_MaxAttemptsExceeded(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "max restart attempts reached")
 
-	// Use Eventually pattern to wait for goroutine completion with retries
-	// This is more robust than fixed time.Sleep in resource-constrained environments
-	assert.Eventually(t, func() bool {
-		// Goroutine should complete and clear the restarting flag (status should not be restarting)
-		// Since we return early with error, status should be Crashed
-		return pm.GetStatus("test-server") == StatusCrashed
-	}, 1*time.Second, 50*time.Millisecond, "goroutine should complete and set status to crashed")
+	// Status should remain Crashed (not modified by RestartServer)
+	assert.Equal(t, StatusCrashed, pm.GetStatus("test-server"))
 
 	// Verify that restart attempts counter was NOT incremented
-	// (because the max attempts check at L173-177 prevented the increment at L178)
+	// (because the max attempts check prevented the increment)
 	assert.Equal(t, 3, pm.GetRestartAttempts("test-server"))
 
 	// Note: We cannot directly verify that connectClient was NOT called without additional
-	// mocking infrastructure, but the unchanged counter and cleared restarting flag
-	// confirm the goroutine exited early as expected.
+	// mocking infrastructure, but the unchanged counter and status confirm early exit.
 }
 
 func TestRestartServer_PolicyNever(t *testing.T) {
@@ -218,11 +215,17 @@ func TestRestartServer_PolicyNever(t *testing.T) {
 
 	cfg := config.ServerConfig{Name: "test-server"}
 
+	// Set initial status to Crashed (as would be set by health check)
+	pm.SetStatus("test-server", StatusCrashed)
+
 	err := cm.RestartServer(context.Background(), cfg)
 
 	// Should return error immediately
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "restart policy does not allow restart")
+
+	// Status should remain Crashed (not modified by RestartServer)
+	assert.Equal(t, StatusCrashed, pm.GetStatus("test-server"))
 
 	// Verify attempts didn't increase
 	assert.Equal(t, 0, pm.GetRestartAttempts("test-server"))

--- a/services/mcp-gateway/internal/mcp/process_manager.go
+++ b/services/mcp-gateway/internal/mcp/process_manager.go
@@ -57,6 +57,24 @@ func (p *ProcessManager) SetStatus(serverName string, status ServerStatus) {
 	p.statuses[serverName] = status
 }
 
+// CompareAndSwapStatus atomically updates the status only if the current status matches expected
+// Returns true if the swap was successful, false otherwise
+func (p *ProcessManager) CompareAndSwapStatus(serverName string, expected, new ServerStatus) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	current, ok := p.statuses[serverName]
+	if !ok {
+		current = StatusUnavailable
+	}
+
+	if current == expected {
+		p.statuses[serverName] = new
+		return true
+	}
+	return false
+}
+
 // GetAllStatuses returns a map of all server statuses
 func (p *ProcessManager) GetAllStatuses() map[string]ServerStatus {
 	p.mu.RLock()


### PR DESCRIPTION
1. Introduced `StatusRestarting`: Added a new server status StatusRestarting in `process_manager.go` to explicitly represent the state where a server is in the process of restarting (including the backoff period).

2. Delayed `restarting` Flag: Modified `RestartServer` in `health_check.go` to:
  - Immediately set the server status to StatusRestarting to prevent duplicate restart attempts.
  - Wait for the backoff period before setting the restarting flag (which blocks API requests). This minimizes the downtime window for clients.
  - Properly handle early exits (policy check, max attempts) by resetting the status to StatusCrashed and cancelling the health check to prevent busy loops.
3. Updated Health Check Logic: Updated `StartHealthCheck` to respect StatusRestarting and avoid triggering crash logic while a restart is already in progress.
4. Enhanced Client Error Handling: Updated `CallTool` in `client_manager.go`
 to check for StatusRestarting and return a specific error message advising the client to retry, as requested.


ref:
- close #135
